### PR TITLE
Placing input values into custom hook reducer formState

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -5,7 +5,7 @@ type ButtonProps = {
   name: string;
   title: string;
   submit?: boolean;
-  icon: string;
+  icon: string | undefined;
 };
 
 const FormBoxButton = ({ name, title, submit, icon }: ButtonProps) => {

--- a/src/components/textfield.tsx
+++ b/src/components/textfield.tsx
@@ -15,14 +15,13 @@ const FormBoxTextField = ({
   dispatchFormAction,
   value,
 }: TextFieldProps) => {
-  console.log("render text field", name, value);
+  // console.log("render text field", name, value);
 
   const handleChange = (e) => {
     dispatchFormAction({
       type: "update_componentProp",
       payload: { name: name, state: { value: e.target.value } },
     });
-    // onChange({ name, value: e.target.value });
   };
 
   return (
@@ -32,7 +31,7 @@ const FormBoxTextField = ({
       required={required}
       variant="outlined"
       onChange={handleChange}
-      value={value}
+      value={value ?? ""}
     />
   );
 };

--- a/src/components/textfield.tsx
+++ b/src/components/textfield.tsx
@@ -1,25 +1,38 @@
 import TextField from "@mui/material/TextField";
+import { dispatchType } from "../types/componentType";
 
 type TextFieldProps = {
   name: string;
   title: string;
   required?: boolean;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-};
+  value: string | undefined;
+} & dispatchType;
 
 const FormBoxTextField = ({
   name,
   title,
   required,
-  onChange,
+  dispatchFormAction,
+  value,
 }: TextFieldProps) => {
+  console.log("render text field", name, value);
+
+  const handleChange = (e) => {
+    dispatchFormAction({
+      type: "update_componentProp",
+      payload: { componentName: name, state: { value: e.target.value } },
+    });
+    // onChange({ name, value: e.target.value });
+  };
+
   return (
     <TextField
       id={name}
       label={title}
       required={required}
       variant="outlined"
-      onChange={onChange}
+      onChange={handleChange}
+      value={value}
     />
   );
 };

--- a/src/components/textfield.tsx
+++ b/src/components/textfield.tsx
@@ -20,7 +20,7 @@ const FormBoxTextField = ({
   const handleChange = (e) => {
     dispatchFormAction({
       type: "update_componentProp",
-      payload: { componentName: name, state: { value: e.target.value } },
+      payload: { name: name, state: { value: e.target.value } },
     });
     // onChange({ name, value: e.target.value });
   };

--- a/src/designer/appbar.tsx
+++ b/src/designer/appbar.tsx
@@ -169,7 +169,7 @@ export default function FormBoxAppBar({
           <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
             {pages.map((page) => {
               return (
-                <Tooltip title={page.tooltip}>
+                <Tooltip key={page.path} title={page.tooltip}>
                   <Typography>
                     <Button
                       onClick={() => navigateToPath(page.path)}

--- a/src/designer/form.tsx
+++ b/src/designer/form.tsx
@@ -1,10 +1,7 @@
-import { useCallback } from "react";
 import Box from "@mui/material/Box";
-import FormBoxComponent from "./formboxcomponent";
-import { dispatchType, formProps } from "../types/componentType";
+import { FormProps } from "../types/componentType";
 import "../css/form.css";
 import Typography from "@mui/material/Typography";
-import { JsxElement } from "typescript";
 
 const style = {
   "& .MuiTextField-root": { mt: 1, mb: 1, width: "25ch" },
@@ -15,13 +12,8 @@ const style = {
   m: 2,
 };
 
-type FormProps = {
-  form: formProps;
-  children: JSX.Element[];
-};
-
-const Form = ({ form, children }: FormProps) => {
-  console.log("form render: ", form);
+const Form = ({ name, title, layout, children }: FormProps) => {
+  // console.log("form render: ", name);
   return (
     <Box component="div" display="grid" justifyContent="center" sx={style}>
       <Typography
@@ -29,7 +21,7 @@ const Form = ({ form, children }: FormProps) => {
         sx={{ color: "text.primary" }}
         variant="h5"
       >
-        {form.title ?? "Form"}
+        {title ?? "Form"}
       </Typography>
       {children}
     </Box>

--- a/src/designer/form.tsx
+++ b/src/designer/form.tsx
@@ -20,11 +20,11 @@ type FormProps = {
 
 const Form = (props: FormProps) => {
   function onChange({ name, value }) {
-    props.onFormChange({
-      formName: props.form.name,
-      componentName: name,
-      value: value,
-    });
+    // props.onFormChange({
+    //   formName: props.form.name,
+    //   componentName: name,
+    //   value: value,
+    // });
   }
 
   // console.log("form render: ", this.state.values);

--- a/src/designer/form.tsx
+++ b/src/designer/form.tsx
@@ -1,6 +1,7 @@
+import { useCallback } from "react";
 import Box from "@mui/material/Box";
 import FormBoxComponent from "./formboxcomponent";
-import { formProps } from "../types/componentType";
+import { dispatchType, formProps } from "../types/componentType";
 import "../css/form.css";
 import Typography from "@mui/material/Typography";
 
@@ -15,20 +16,12 @@ const style = {
 
 type FormProps = {
   form: formProps;
-  onFormChange: ({ formName, componentName, value }) => void;
-};
+} & dispatchType;
 
 const Form = (props: FormProps) => {
-  function onChange({ name, value }) {
-    // props.onFormChange({
-    //   formName: props.form.name,
-    //   componentName: name,
-    //   value: value,
-    // });
-  }
-
-  // console.log("form render: ", this.state.values);
+  console.log("form render: ", props.form);
   let components = props.form.components;
+  const dispatchFormAction = useCallback(props.dispatchFormAction, []);
   return (
     <Box component="div" display="grid" justifyContent="center" sx={style}>
       <Typography
@@ -38,9 +31,20 @@ const Form = (props: FormProps) => {
       >
         {props.form.title ?? "Form"}
       </Typography>
-      {components.map((component, i) => {
+      {components.map((component) => {
         return (
-          <FormBoxComponent key={i} component={component} onChange={onChange} />
+          <FormBoxComponent
+            key={component.name}
+            name={component.name}
+            title={component.title}
+            help={component.help}
+            type={component.type}
+            required={component.required}
+            value={component.value}
+            icon={component.icon}
+            submit={component.submit}
+            dispatchFormAction={dispatchFormAction}
+          />
         );
       })}
     </Box>

--- a/src/designer/form.tsx
+++ b/src/designer/form.tsx
@@ -4,6 +4,7 @@ import FormBoxComponent from "./formboxcomponent";
 import { dispatchType, formProps } from "../types/componentType";
 import "../css/form.css";
 import Typography from "@mui/material/Typography";
+import { JsxElement } from "typescript";
 
 const style = {
   "& .MuiTextField-root": { mt: 1, mb: 1, width: "25ch" },
@@ -16,12 +17,11 @@ const style = {
 
 type FormProps = {
   form: formProps;
-} & dispatchType;
+  children: JSX.Element[];
+};
 
-const Form = (props: FormProps) => {
-  console.log("form render: ", props.form);
-  let components = props.form.components;
-  const dispatchFormAction = useCallback(props.dispatchFormAction, []);
+const Form = ({ form, children }: FormProps) => {
+  console.log("form render: ", form);
   return (
     <Box component="div" display="grid" justifyContent="center" sx={style}>
       <Typography
@@ -29,24 +29,9 @@ const Form = (props: FormProps) => {
         sx={{ color: "text.primary" }}
         variant="h5"
       >
-        {props.form.title ?? "Form"}
+        {form.title ?? "Form"}
       </Typography>
-      {components.map((component) => {
-        return (
-          <FormBoxComponent
-            key={component.name}
-            name={component.name}
-            title={component.title}
-            help={component.help}
-            type={component.type}
-            required={component.required}
-            value={component.value}
-            icon={component.icon}
-            submit={component.submit}
-            dispatchFormAction={dispatchFormAction}
-          />
-        );
-      })}
+      {children}
     </Box>
   );
 };

--- a/src/designer/formbox.tsx
+++ b/src/designer/formbox.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { Container, Box, Button } from "@mui/material";
 import { useParams } from "react-router-dom";
 
@@ -8,6 +8,7 @@ import exampleFormJSON from "../exampleforms/jobposition.json";
 
 import Typography from "@mui/material/Typography";
 import SaveAltIcon from "@mui/icons-material/SaveAlt";
+import { flattenFormJSON } from "../helpers/utils";
 
 const style = {
   bgcolor: "background.paper",
@@ -18,7 +19,7 @@ const style = {
 };
 
 const FormBox = ({ dispatchFormAction, setSnackbar, children }) => {
-  const [values, setValues] = useState({});
+  // const [values, setValues] = useState({});
   const { formState } = useContext(FormBoxContext);
   const { formJSON, formName } = formState;
 
@@ -59,21 +60,21 @@ const FormBox = ({ dispatchFormAction, setSnackbar, children }) => {
     }
   }, [form, dispatchFormAction, setSnackbar]);
 
-  function processValues(values) {
-    let returnValues = {};
-    for (const form in values) {
-      let formValues = values[form];
-      for (const inputValue in formValues) {
-        returnValues[inputValue] = formValues[inputValue];
+  function processValues() {
+    const objects = flattenFormJSON(formJSON);
+    const values = {};
+    objects.forEach((object) => {
+      if (object.value !== undefined) {
+        values[object.name] = object.value;
       }
-    }
-    return returnValues;
+    });
+    return values;
   }
 
   function onSubmit() {
     let formToSubmit = {
       formName: formName,
-      ...processValues(values),
+      ...processValues(),
     };
     console.log("submit", formToSubmit);
     submitFormValues(formToSubmit);
@@ -102,7 +103,7 @@ const FormBox = ({ dispatchFormAction, setSnackbar, children }) => {
       .catch((res) => console.log("error from api: ", res));
   }
 
-  console.log("FORMBOX render :", formJSON);
+  // console.log("FORMBOX render :", formJSON);
   if (formJSON) {
     return (
       <Container

--- a/src/designer/formbox.tsx
+++ b/src/designer/formbox.tsx
@@ -4,7 +4,6 @@ import { useParams } from "react-router-dom";
 
 import { FormBoxContext } from "./formbuilder";
 import { loadForm } from "../helpers/formrequest";
-import Form from "./form";
 import exampleFormJSON from "../exampleforms/jobposition.json";
 
 import Typography from "@mui/material/Typography";
@@ -18,7 +17,7 @@ const style = {
   boxShadow: "4px 4px 12px #e0e0e0",
 };
 
-const FormBox = ({ dispatchFormAction, setSnackbar }) => {
+const FormBox = ({ dispatchFormAction, setSnackbar, children }) => {
   const [values, setValues] = useState({});
   const { formState } = useContext(FormBoxContext);
   const { formJSON, formName } = formState;
@@ -104,7 +103,6 @@ const FormBox = ({ dispatchFormAction, setSnackbar }) => {
   }
 
   console.log("FORMBOX render :", formJSON);
-  let forms = formJSON?.forms;
   if (formJSON) {
     return (
       <Container
@@ -122,15 +120,7 @@ const FormBox = ({ dispatchFormAction, setSnackbar }) => {
         <Typography sx={{ color: "text.primary", ml: 2 }} variant="h2">
           {formJSON?.title}
         </Typography>
-        {forms?.map((form) => {
-          return (
-            <Form
-              key={form.name}
-              form={form}
-              dispatchFormAction={dispatchFormAction}
-            />
-          );
-        })}
+        {children}
         <Box
           display="flex"
           justifyContent={"right"}

--- a/src/designer/formbox.tsx
+++ b/src/designer/formbox.tsx
@@ -60,18 +60,6 @@ const FormBox = ({ dispatchFormAction, setSnackbar }) => {
     }
   }, [form, dispatchFormAction, setSnackbar]);
 
-  function onFormChange({ formName, componentName, value }) {
-    setValues({
-      ...values,
-      ...{
-        [formName]: {
-          ...values?.[formName],
-          ...{ [componentName]: value },
-        },
-      },
-    });
-  }
-
   function processValues(values) {
     let returnValues = {};
     for (const form in values) {
@@ -115,7 +103,7 @@ const FormBox = ({ dispatchFormAction, setSnackbar }) => {
       .catch((res) => console.log("error from api: ", res));
   }
 
-  // console.log("FORMBOX render :", this);
+  console.log("FORMBOX render :", formJSON);
   let forms = formJSON?.forms;
   if (formJSON) {
     return (
@@ -134,8 +122,14 @@ const FormBox = ({ dispatchFormAction, setSnackbar }) => {
         <Typography sx={{ color: "text.primary", ml: 2 }} variant="h2">
           {formJSON?.title}
         </Typography>
-        {forms?.map((form, i) => {
-          return <Form key={i} form={form} onFormChange={onFormChange} />;
+        {forms?.map((form) => {
+          return (
+            <Form
+              key={form.name}
+              form={form}
+              dispatchFormAction={dispatchFormAction}
+            />
+          );
         })}
         <Box
           display="flex"

--- a/src/designer/formboxcomponent.tsx
+++ b/src/designer/formboxcomponent.tsx
@@ -1,61 +1,51 @@
+import { useEffect } from "react";
 import { FormControl, FormHelperText } from "@mui/material";
-import FormBoxButton from "../components/button";
-import FormBoxTextField from "../components/textfield";
-import { componentProps } from "../types/componentType";
+import { componentProps, dispatchType } from "../types/componentType";
+import FormBoxControl from "../designer/formboxcontrol";
 
 type CompProps = {
-  key: number;
-  component: componentProps;
-  onChange: ({ name, value }) => void;
+  key: string;
+} & componentProps &
+  dispatchType;
+
+const WrapFormControl = ({ children, name, help }) => (
+  <FormControl variant="standard">
+    {children}
+    <FormHelperText id={name + "helptext"}>{help}</FormHelperText>
+  </FormControl>
+);
+
+const FormBoxComponent: React.FC<CompProps> = ({
+  name,
+  title,
+  help,
+  type,
+  required,
+  value,
+  submit,
+  icon,
+  dispatchFormAction,
+}) => {
+  console.log("component render:", name);
+  return (
+    <WrapFormControl name={name} help={help}>
+      <FormBoxControl
+        key={name}
+        name={name}
+        title={title}
+        help={help}
+        type={type}
+        required={required}
+        value={value}
+        icon={icon}
+        submit={submit}
+        dispatchFormAction={dispatchFormAction}
+      />
+    </WrapFormControl>
+  );
 };
 
-const FormBoxComponent = (props: CompProps) => {
-  function onChange(e: any) {
-    let component = props.component;
-    let value = e.target.value;
-    props.onChange({ name: component.name, value: value });
-  }
-
-  function getComponent(component: any) {
-    if (component.type === "textfield") {
-      return (
-        <FormBoxTextField
-          name={component.name}
-          title={component.title}
-          required={component.required}
-          onChange={onChange}
-        />
-      );
-    } else if (component.type === "button") {
-      return (
-        <FormBoxButton
-          name={component.name}
-          title={component.title}
-          submit={component.submit}
-          icon={component.icon}
-        />
-      );
-    } else {
-      return <div>FormBoxComponent</div>;
-    }
-  }
-
-  function getFormControl(control: any, component: any) {
-    return (
-      <FormControl variant="standard">
-        {control}
-        <FormHelperText id={component.name + "helptext"}>
-          {component.help}
-        </FormHelperText>
-      </FormControl>
-    );
-  }
-
-  let component = props.component;
-  // console.log("component:", this);
-  let control = getComponent(component);
-  let componentObject = getFormControl(control, component);
-  return componentObject;
-};
-
+// const MemoizedComponent: React.FC<CompProps> = (props) => {
+//   return useMemo(() => <FormBoxComponent {...props} />, [props.component]);
+// };
 export default FormBoxComponent;

--- a/src/designer/formboxcomponent.tsx
+++ b/src/designer/formboxcomponent.tsx
@@ -15,16 +15,11 @@ const WrapFormControl = ({ children, name, help }) => (
   </FormControl>
 );
 
-// const arePropsEqual = (prevProps, newProps) => {
-//   console.log("arePropsEqual: ", prevProps, newProps);
-//   return true;
-// };
-
 const FormBoxComponent: React.FC<CompProps> = ({
   component,
   dispatchFormAction,
 }) => {
-  console.log("component render:", component.name);
+  // console.log("component render:", component.name);
   return (
     <WrapFormControl name={component.name} help={component.help}>
       <FormBoxControl
@@ -36,4 +31,6 @@ const FormBoxComponent: React.FC<CompProps> = ({
   );
 };
 
-export default FormBoxComponent;
+const memoizedFormBoxComponent: React.FC<CompProps> = memo(FormBoxComponent);
+
+export default memoizedFormBoxComponent;

--- a/src/designer/formboxcomponent.tsx
+++ b/src/designer/formboxcomponent.tsx
@@ -1,12 +1,12 @@
-import { useEffect } from "react";
+import { memo } from "react";
 import { FormControl, FormHelperText } from "@mui/material";
 import { componentProps, dispatchType } from "../types/componentType";
 import FormBoxControl from "../designer/formboxcontrol";
 
 type CompProps = {
   key: string;
-} & componentProps &
-  dispatchType;
+  component: componentProps;
+} & dispatchType;
 
 const WrapFormControl = ({ children, name, help }) => (
   <FormControl variant="standard">
@@ -15,37 +15,25 @@ const WrapFormControl = ({ children, name, help }) => (
   </FormControl>
 );
 
+// const arePropsEqual = (prevProps, newProps) => {
+//   console.log("arePropsEqual: ", prevProps, newProps);
+//   return true;
+// };
+
 const FormBoxComponent: React.FC<CompProps> = ({
-  name,
-  title,
-  help,
-  type,
-  required,
-  value,
-  submit,
-  icon,
+  component,
   dispatchFormAction,
 }) => {
-  console.log("component render:", name);
+  console.log("component render:", component.name);
   return (
-    <WrapFormControl name={name} help={help}>
+    <WrapFormControl name={component.name} help={component.help}>
       <FormBoxControl
-        key={name}
-        name={name}
-        title={title}
-        help={help}
-        type={type}
-        required={required}
-        value={value}
-        icon={icon}
-        submit={submit}
+        key={component.name}
+        component={component}
         dispatchFormAction={dispatchFormAction}
       />
     </WrapFormControl>
   );
 };
 
-// const MemoizedComponent: React.FC<CompProps> = (props) => {
-//   return useMemo(() => <FormBoxComponent {...props} />, [props.component]);
-// };
 export default FormBoxComponent;

--- a/src/designer/formboxcontrol.tsx
+++ b/src/designer/formboxcontrol.tsx
@@ -2,19 +2,12 @@ import FormBoxButton from "../components/button";
 import FormBoxTextField from "../components/textfield";
 import { componentProps, dispatchType } from "../types/componentType";
 
-type CompProps = componentProps & dispatchType;
+type CompProps = { component: componentProps } & dispatchType;
 
-function FormBoxControl({
-  name,
-  title,
-  type,
-  required,
-  value,
-  submit,
-  icon,
-  dispatchFormAction,
-}: CompProps) {
+function FormBoxControl({ component, dispatchFormAction }: CompProps) {
+  const { name, title, type, value, required, submit, icon } = component;
   console.log("FormBoxcontrol: ", name);
+
   if (type === "textfield") {
     return (
       <FormBoxTextField

--- a/src/designer/formboxcontrol.tsx
+++ b/src/designer/formboxcontrol.tsx
@@ -6,7 +6,6 @@ type CompProps = { component: componentProps } & dispatchType;
 
 function FormBoxControl({ component, dispatchFormAction }: CompProps) {
   const { name, title, type, value, required, submit, icon } = component;
-  console.log("FormBoxcontrol: ", name);
 
   if (type === "textfield") {
     return (

--- a/src/designer/formboxcontrol.tsx
+++ b/src/designer/formboxcontrol.tsx
@@ -1,0 +1,37 @@
+import FormBoxButton from "../components/button";
+import FormBoxTextField from "../components/textfield";
+import { componentProps, dispatchType } from "../types/componentType";
+
+type CompProps = componentProps & dispatchType;
+
+function FormBoxControl({
+  name,
+  title,
+  type,
+  required,
+  value,
+  submit,
+  icon,
+  dispatchFormAction,
+}: CompProps) {
+  console.log("FormBoxcontrol: ", name);
+  if (type === "textfield") {
+    return (
+      <FormBoxTextField
+        name={name}
+        title={title}
+        required={required}
+        dispatchFormAction={dispatchFormAction}
+        value={value}
+      />
+    );
+  } else if (type === "button") {
+    return (
+      <FormBoxButton name={name} title={title} submit={submit} icon={icon} />
+    );
+  } else {
+    return <div>FormBoxComponent</div>;
+  }
+}
+
+export default FormBoxControl;

--- a/src/designer/formbuilder.tsx
+++ b/src/designer/formbuilder.tsx
@@ -63,7 +63,7 @@ const getUsername = () => {
 const FormBuilder = () => {
   // State
   const [formState, dispatchFormAction] = useFormStateReducer();
-  console.log("formBuilder", formState);
+  // console.log("formBuilder", formState);
   const [user, setUser] = useState({
     username: getUsername(),
     token: getToken(),
@@ -137,21 +137,23 @@ const FormBuilder = () => {
           dispatchFormAction={dispatchFormAction}
           setSnackbar={setSnackbar}
         >
-          {formState.formJSON?.forms?.map((form) => {
-            return (
-              <Form key={form.name} form={form}>
-                {form.components?.map((component) => {
-                  return (
-                    <FormBoxComponent
-                      key={component.name}
-                      component={component}
-                      dispatchFormAction={dispatchFormAction}
-                    />
-                  );
-                })}
-              </Form>
-            );
-          })}
+          {formState.formJSON?.forms?.map((form) => (
+            <Form
+              key={form.name}
+              name={form.name}
+              type={form.type}
+              layout={form.layout}
+              title={form.title}
+            >
+              {form.components?.map((component) => (
+                <FormBoxComponent
+                  key={component.name}
+                  component={component}
+                  dispatchFormAction={dispatchFormAction}
+                />
+              ))}
+            </Form>
+          ))}
         </FormBox>
       ),
       errorElement: <ErrorPage />,

--- a/src/designer/formbuilder.tsx
+++ b/src/designer/formbuilder.tsx
@@ -7,6 +7,8 @@ import FormBoxAppBar from "./appbar";
 import FormDataGridPage from "./formdatagridpage";
 import JSONEditorPage from "./jsoneditorpage";
 import FormBoxSnackbar from "./snackbar";
+import Form from "./form";
+import FormBoxComponent from "./formboxcomponent";
 
 import { getForms, connectToDb, disconnectDb } from "../helpers/formrequest";
 import { useFormStateReducer } from "../hooks/formStateReducer";
@@ -134,7 +136,23 @@ const FormBuilder = () => {
         <FormBox
           dispatchFormAction={dispatchFormAction}
           setSnackbar={setSnackbar}
-        />
+        >
+          {formState.formJSON.forms?.map((form) => {
+            return (
+              <Form key={form.name} form={form}>
+                {form.components?.map((component) => {
+                  return (
+                    <FormBoxComponent
+                      key={component.name}
+                      component={component}
+                      dispatchFormAction={dispatchFormAction}
+                    />
+                  );
+                })}
+              </Form>
+            );
+          })}
+        </FormBox>
       ),
       errorElement: <ErrorPage />,
     },

--- a/src/designer/formbuilder.tsx
+++ b/src/designer/formbuilder.tsx
@@ -137,7 +137,7 @@ const FormBuilder = () => {
           dispatchFormAction={dispatchFormAction}
           setSnackbar={setSnackbar}
         >
-          {formState.formJSON.forms?.map((form) => {
+          {formState.formJSON?.forms?.map((form) => {
             return (
               <Form key={form.name} form={form}>
                 {form.components?.map((component) => {

--- a/src/designer/formbuilder.tsx
+++ b/src/designer/formbuilder.tsx
@@ -61,6 +61,7 @@ const getUsername = () => {
 const FormBuilder = () => {
   // State
   const [formState, dispatchFormAction] = useFormStateReducer();
+  console.log("formBuilder", formState);
   const [user, setUser] = useState({
     username: getUsername(),
     token: getToken(),

--- a/src/designer/formbuilder.tsx
+++ b/src/designer/formbuilder.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import ErrorPage from "./errorpage";
@@ -6,13 +6,13 @@ import FormBox from "./formbox";
 import FormBoxAppBar from "./appbar";
 import FormDataGridPage from "./formdatagridpage";
 import JSONEditorPage from "./jsoneditorpage";
+import FormBoxSnackbar from "./snackbar";
 
 import { getForms, connectToDb, disconnectDb } from "../helpers/formrequest";
-
+import { useFormStateReducer } from "../hooks/formStateReducer";
 import { FormBoxContextType } from "../types/componentType";
 
 import "../css/formbuilder.css";
-import FormBoxSnackbar from "./snackbar";
 
 // css
 import "../App.css";
@@ -49,39 +49,6 @@ export const FormBoxContext = React.createContext<FormBoxContextType>({
 });
 
 // Global functions
-function createInitialFormState() {
-  return {
-    JSON: undefined,
-    formName: undefined,
-  };
-}
-
-function formStateReducer(state, action) {
-  switch (action.type) {
-    case "update_formName": {
-      return {
-        ...state,
-        formName: action.payload.formName,
-      };
-    }
-    case "update_JSON": {
-      return {
-        ...state,
-        formJSON: action.payload.formJSON,
-      };
-    }
-    case "update_formState": {
-      return {
-        ...state,
-        ...action.payload.formState,
-      };
-    }
-    default: {
-      console.error("Unknown action:", action);
-      throw Error("Unknown action: " + action.type);
-    }
-  }
-}
 
 const getToken = () => {
   return sessionStorage.getItem("token") ?? undefined;
@@ -93,15 +60,7 @@ const getUsername = () => {
 
 const FormBuilder = () => {
   // State
-  const [formState, dispatchFormAction] = useReducer(
-    formStateReducer,
-    {
-      formJSON: undefined,
-      formName: undefined,
-    },
-    createInitialFormState
-  );
-
+  const [formState, dispatchFormAction] = useFormStateReducer();
   const [user, setUser] = useState({
     username: getUsername(),
     token: getToken(),

--- a/src/designer/profilemenu.tsx
+++ b/src/designer/profilemenu.tsx
@@ -113,10 +113,7 @@ export default function ProfileMenu({ user, handleSetUser, setSnackbar }) {
     <Box>
       <Tooltip title="User Profile">
         <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-          <Avatar
-            alt={user.username ?? undefined}
-            src="/static/images/avatar/2.jpg"
-          />
+          <Avatar alt={user.username ?? undefined}>{user.username?.[0]}</Avatar>
         </IconButton>
       </Tooltip>
       <Menu

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,0 +1,11 @@
+export function flattenFormJSON(formJSON, arrayOfObjects = []) {
+  if (formJSON !== undefined) {
+    arrayOfObjects.push(formJSON);
+    if (formJSON.forms?.length > 0) {
+      formJSON.forms.forEach((form) => flattenFormJSON(form, arrayOfObjects));
+    } else if (formJSON.components?.length > 0) {
+      formJSON.components.forEach((comp) => arrayOfObjects.push(comp));
+    }
+  }
+  return arrayOfObjects;
+}

--- a/src/hooks/formStateReducer.js
+++ b/src/hooks/formStateReducer.js
@@ -8,7 +8,7 @@ function createInitialFormState() {
 }
 
 function updateComponentByName({ formJSON, name, state }) {
-  // console.log("updateComponentByName", { formJSON, name, state });
+  console.log("updateComponentByName", { formJSON, name, state });
   if (formJSON.name === name) {
     return { ...formJSON, ...state };
   } else if (formJSON.forms?.length > 0) {
@@ -28,6 +28,7 @@ function updateComponentByName({ formJSON, name, state }) {
       var comp = components[i];
       if (comp.name === name) {
         components[i] = { ...comp, ...state };
+        console.log("found component :", components[i]);
         return;
       }
     }
@@ -43,6 +44,7 @@ function reducer(state, action) {
         name: action.payload.name,
         state: action.payload.state,
       });
+      console.log("after comp update:", formJSON);
       return { ...state, formJSON: formJSON };
     }
     case "update_formName": {

--- a/src/hooks/formStateReducer.js
+++ b/src/hooks/formStateReducer.js
@@ -1,0 +1,45 @@
+import { useReducer } from "react";
+
+function createInitialFormState() {
+  return {
+    JSON: undefined,
+    formName: undefined,
+  };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "update_formName": {
+      return {
+        ...state,
+        formName: action.payload.formName,
+      };
+    }
+    case "update_JSON": {
+      return {
+        ...state,
+        formJSON: action.payload.formJSON,
+      };
+    }
+    case "update_formState": {
+      return {
+        ...state,
+        ...action.payload.formState,
+      };
+    }
+    default: {
+      console.error("Unknown action:", action);
+      throw Error("Unknown action: " + action.type);
+    }
+  }
+}
+
+const initialState = {
+  JSON: undefined,
+  formName: undefined,
+};
+
+export const useFormStateReducer = () => {
+  return useReducer(reducer, initialState, createInitialFormState);
+  //   return [ formState, dispatchFormAction ];
+};

--- a/src/hooks/formStateReducer.js
+++ b/src/hooks/formStateReducer.js
@@ -8,30 +8,25 @@ function createInitialFormState() {
 }
 
 function updateComponentByName({ formJSON, name, state }) {
-  console.log("updateComponentByName", { formJSON, name, state });
+  // console.log("updateComponentByName", { formJSON, name, state });
   if (formJSON.name === name) {
     return { ...formJSON, ...state };
   } else if (formJSON.forms?.length > 0) {
-    var forms = formJSON.forms;
-    for (var i = 0; i < forms.length; i++) {
-      var form = forms[i];
+    formJSON.forms.forEach((form, i) => {
       if (form.name === name) {
-        forms[i] = { ...form, ...state };
+        formJSON.forms[i] = { ...form, ...state };
         return;
       } else {
         updateComponentByName({ formJSON: form, name, state });
       }
-    }
+    });
   } else if (formJSON.components?.length > 0) {
-    var components = formJSON.components;
-    for (var i = 0; i < components.length; i++) {
-      var comp = components[i];
+    formJSON.components.forEach((comp, j) => {
       if (comp.name === name) {
-        components[i] = { ...comp, ...state };
-        console.log("found component :", components[i]);
+        formJSON.components[j] = { ...comp, ...state };
         return;
       }
-    }
+    });
   }
 }
 
@@ -44,7 +39,7 @@ function reducer(state, action) {
         name: action.payload.name,
         state: action.payload.state,
       });
-      console.log("after comp update:", formJSON);
+      // console.log("after comp update:", formJSON);
       return { ...state, formJSON: formJSON };
     }
     case "update_formName": {

--- a/src/hooks/formStateReducer.js
+++ b/src/hooks/formStateReducer.js
@@ -2,13 +2,49 @@ import { useReducer } from "react";
 
 function createInitialFormState() {
   return {
-    JSON: undefined,
+    formJSON: undefined,
     formName: undefined,
   };
 }
 
+function updateComponentByName({ formJSON, name, state }) {
+  // console.log("updateComponentByName", { formJSON, name, state });
+  if (formJSON.name === name) {
+    return { ...formJSON, ...state };
+  } else if (formJSON.forms?.length > 0) {
+    var forms = formJSON.forms;
+    for (var i = 0; i < forms.length; i++) {
+      var form = forms[i];
+      if (form.name === name) {
+        forms[i] = { ...form, ...state };
+        return;
+      } else {
+        updateComponentByName({ formJSON: form, name, state });
+      }
+    }
+  } else if (formJSON.components?.length > 0) {
+    var components = formJSON.components;
+    for (var i = 0; i < components.length; i++) {
+      var comp = components[i];
+      if (comp.name === name) {
+        components[i] = { ...comp, ...state };
+        return;
+      }
+    }
+  }
+}
+
 function reducer(state, action) {
   switch (action.type) {
+    case "update_componentProp": {
+      var formJSON = state.formJSON;
+      updateComponentByName({
+        formJSON: formJSON,
+        name: action.payload.name,
+        state: action.payload.state,
+      });
+      return { ...state, formJSON: formJSON };
+    }
     case "update_formName": {
       return {
         ...state,
@@ -35,11 +71,10 @@ function reducer(state, action) {
 }
 
 const initialState = {
-  JSON: undefined,
+  formJSON: undefined,
   formName: undefined,
 };
 
 export const useFormStateReducer = () => {
   return useReducer(reducer, initialState, createInitialFormState);
-  //   return [ formState, dispatchFormAction ];
 };

--- a/src/types/componentType.ts
+++ b/src/types/componentType.ts
@@ -16,7 +16,8 @@ export type componentProps = defaultProps & {
   help?: string;
   required?: boolean;
   submit?: boolean;
-  iconName: string | undefined;
+  icon: string | undefined;
+  value: any | undefined;
 };
 
 export type formBoxAppBarProps = {
@@ -49,4 +50,8 @@ export type FormBoxContextType = {
     token: string | null | undefined;
   };
   listOfForms: formDataProps[];
+};
+
+export type dispatchType = {
+  dispatchFormAction: ({ type, payload }) => void;
 };

--- a/src/types/componentType.ts
+++ b/src/types/componentType.ts
@@ -27,15 +27,15 @@ export type formBoxAppBarProps = {
 };
 
 export type container = {
-  forms: formProps[];
+  forms: FormProps[];
   layout: string;
   title: string;
   name: string;
   type: string;
 };
 
-export type formProps = defaultProps & {
-  components: componentProps[];
+export type FormProps = defaultProps & {
+  children: JSX.Element[];
   layout: string;
   type: string;
 };


### PR DESCRIPTION
Moving input values from a state in formbox to a custom hook formState that lives at the highest level of the app.,formbuilder. This allows the value properties to be contained within the formState along side all teh other UI schema properties. 

Memoizing the components optimizes performance by only rerendering them if their properties have changed in the new reducer function to update component state. Returning a new component object.